### PR TITLE
Removed win from conda convert

### DIFF
--- a/ci/build-conda-package.sh
+++ b/ci/build-conda-package.sh
@@ -22,7 +22,9 @@ echo "building ${pkgname} ${pkgversion}"
 # build conda for default OS and then cross-compile for other OS
 mkdir ~/conda-builds/
 conda package --pkg-name "$pkgname" --pkg-version "$pkgversion"
-conda convert --platform all "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
+conda convert --platform  linux-64  "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
+conda convert --platform  linux-32  "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
+conda convert --platform  osx-64  "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
 
 # index for the conda <=4.0 format
 cd ~/${bucket_name}

--- a/ci/build-conda-package.sh
+++ b/ci/build-conda-package.sh
@@ -25,6 +25,7 @@ conda package --pkg-name "$pkgname" --pkg-version "$pkgversion"
 conda convert --platform  linux-64  "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
 conda convert --platform  linux-32  "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
 conda convert --platform  osx-64  "./yhat-${pkgversion}-py27_0.tar.bz2" -o ~/conda-builds/
+echo "Converted to linux-32, linux-64, and osx-64. Converting to windows is no longer available"
 
 # index for the conda <=4.0 format
 cd ~/${bucket_name}


### PR DESCRIPTION
Circle builds are now breaking because of a weird issue converting to win-32. We are going to remove win-32 and win-64 from `conda convert` by specifying each platform rather than using `all1